### PR TITLE
Update pis-functions.php to avoid erroring

### DIFF
--- a/inc/pis-functions.php
+++ b/inc/pis-functions.php
@@ -1073,7 +1073,7 @@ function pis_custom_taxonomies_terms_links( $args ) {
 		if ( 'category' != $taxonomy_slug && 'post_tag' != $taxonomy_slug ) {
 			// get the terms related to post
 			$list_of_terms = get_the_term_list( $postID, $taxonomy_slug, $term_hashtag, $term_sep . ' ' . $term_hashtag, '' );
-			if ( $list_of_terms ) {
+			if ( !(is_wp_error( $list_of_terms )) && ( $list_of_terms )) {
 				$output .= '<p ' . pis_paragraph( $terms_margin, $margin_unit, 'pis-terms-links pis-' . $taxonomy_slug, 'pis_terms_class' ) . '>';
 					$output .= '<span class="pis-tax-name">' . $taxonomy->label . '</span>: ' . apply_filters( 'pis_terms_list', $list_of_terms );
 				$output .= '</p>';


### PR DESCRIPTION
When dealing with taxonomies, PIS expects to receive a valid set of taxonomy details to work with. However, for sites which use CPT-onomies, there is a long outstanding bug which populates term cache in WP 4.7.2 and above with NULLs, hence when PIS touches such a Post, as it wasn't expecting a NULL it would cause to error out and the page with the post on would not get properly generated. An additional check for a WP_Error return value is now added to handle this circumstance.